### PR TITLE
Install specific danger-go version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,7 @@ jobs:
           go-version: '^1.19'
 
       - name: Install danger-go
-        run: go install github.com/moolmanruan/danger-go/cmd/danger-go@latest
-
-#      - name: Install danger-go from source
-#        run: go install github.com/moolmanruan/danger-go/cmd/danger-go
+        run: go install github.com/moolmanruan/danger-go/cmd/danger-go@v0.0.3 # match version used in build/ci
 
       - name: Check versions
         run: |


### PR DESCRIPTION
If the version of `danger-go` used in the *dangerfile.go* plugin package differs from the version of the `danger-go` command installed, an error occurs when the plugin is built.