### PR TITLE
Add Results method to danger.T

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,12 +1,17 @@
 package danger
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type T struct {
-	Results Results
+	results Results
 }
 
 func New() *T {
 	return &T{
-		Results: Results{
+		results: Results{
 			Fails:     []Violation{},
 			Messages:  []Violation{},
 			Warnings:  []Violation{},
@@ -15,10 +20,20 @@ func New() *T {
 	}
 }
 
+// Results returns the JSON marshalled from the messages, warnings, failures,
+// and markdowns that was added so far.
+func (s *T) Results() (string, error) {
+	bb, err := json.Marshal(s.results)
+	if err != nil {
+		return "", fmt.Errorf("marshalling results: %w", err)
+	}
+	return string(bb), nil
+}
+
 // Message adds the message to the Danger table. The only difference between
 // this and Warn is the emoji which shows in the table.
 func (s *T) Message(message string, file string, line int) {
-	s.Results.Messages = append(s.Results.Messages,
+	s.results.Messages = append(s.results.Messages,
 		Violation{
 			Message: message,
 			File:    file,
@@ -29,7 +44,7 @@ func (s *T) Message(message string, file string, line int) {
 // Warn adds the message to the Danger table. The message highlights
 // low-priority issues, but does not fail the build.
 func (s *T) Warn(message string, file string, line int) {
-	s.Results.Warnings = append(s.Results.Warnings,
+	s.results.Warnings = append(s.results.Warnings,
 		Violation{
 			Message: message,
 			File:    file,
@@ -39,7 +54,7 @@ func (s *T) Warn(message string, file string, line int) {
 
 // Fail a build, outputting a specific reason for failing into an HTML table.
 func (s *T) Fail(message string, file string, line int) {
-	s.Results.Fails = append(s.Results.Fails,
+	s.results.Fails = append(s.results.Fails,
 		Violation{
 			Message: message,
 			File:    file,
@@ -50,7 +65,7 @@ func (s *T) Fail(message string, file string, line int) {
 // Markdown adds the message as raw markdown into the Danger comment, under the
 // table.
 func (s *T) Markdown(message string, file string, line int) {
-	s.Results.Markdowns = append(s.Results.Markdowns,
+	s.results.Markdowns = append(s.results.Markdowns,
 		Violation{
 			Message: message,
 			File:    file,

--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -1,0 +1,54 @@
+package danger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessage(t *testing.T) {
+	d := New()
+
+	d.Message("a message", "", 0)
+
+	require.Equal(t,
+		[]Violation{
+			{Message: "a message"},
+		},
+		d.results.Messages)
+}
+
+func TestWarn(t *testing.T) {
+	d := New()
+
+	d.Warn("a warning", "", 0)
+
+	require.Equal(t,
+		[]Violation{
+			{Message: "a warning"},
+		},
+		d.results.Warnings)
+}
+
+func TestFail(t *testing.T) {
+	d := New()
+	d.Fail("a failure", "", 0)
+
+	require.Equal(t,
+		[]Violation{
+			{Message: "a failure"},
+		},
+		d.results.Fails)
+}
+
+func TestMarkdown(t *testing.T) {
+	d := New()
+
+	d.Markdown("some markdown", "", 0)
+
+	require.Equal(t,
+		[]Violation{
+			{Message: "some markdown"},
+		},
+		d.results.Markdowns)
+}

--- a/api_test.go
+++ b/api_test.go
@@ -7,49 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMessage(t *testing.T) {
+func TestResults(t *testing.T) {
 	d := danger.New()
+	r, err := d.Results()
+	require.Nil(t, err)
+	require.Equal(t, `{"fails":[],"warnings":[],"messages":[],"markdowns":[]}`, r)
 
-	d.Message("a message", "", 0)
-
-	require.Equal(t,
-		[]danger.Violation{
-			{Message: "a message"},
-		},
-		d.Results.Messages)
-}
-
-func TestWarn(t *testing.T) {
-	d := danger.New()
-
-	d.Warn("a warning", "", 0)
-
-	require.Equal(t,
-		[]danger.Violation{
-			{Message: "a warning"},
-		},
-		d.Results.Warnings)
-}
-
-func TestFail(t *testing.T) {
-	d := danger.New()
-	d.Fail("a failure", "", 0)
-
-	require.Equal(t,
-		[]danger.Violation{
-			{Message: "a failure"},
-		},
-		d.Results.Fails)
-}
-
-func TestMarkdown(t *testing.T) {
-	d := danger.New()
-
-	d.Markdown("some markdown", "", 0)
-
-	require.Equal(t,
-		[]danger.Violation{
-			{Message: "some markdown"},
-		},
-		d.Results.Markdowns)
+	d.Message("test", "", 0)
+	r, err = d.Results()
+	require.Nil(t, err)
+	require.Equal(t, `{"fails":[],"warnings":[],"messages":[{"message":"test"}],"markdowns":[]}`, r)
 }

--- a/cmd/danger-go/runner/runner.go
+++ b/cmd/danger-go/runner/runner.go
@@ -63,11 +63,11 @@ func Run() {
 
 	d := danger.New()
 	fn(d, jsonData.Danger)
-	respJSON, err := json.Marshal(d.Results)
+	respJSON, err := d.Results()
 	if err != nil {
 		log.Fatalf("marshalling response: %s", err.Error())
 	}
-	fmt.Print(string(respJSON))
+	fmt.Print(respJSON)
 }
 
 // buildPlugin builds the plugin and stores the artifacts in a temporary


### PR DESCRIPTION
This change makes the current *Results* field of *danger.T* private and adds the *Results* method. This means that the results cannot be changed once message, failures, etc. was added.