### PR TITLE
Alias dangerJs.DSL in root danger package

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,7 +3,13 @@ package danger
 import (
 	"encoding/json"
 	"fmt"
+
+	dangerJs "github.com/moolmanruan/danger-go/danger-js"
 )
+
+// DSL wraps the DSL received from danger JS. This allows dangerfiles to only
+// import the root danger package.
+type DSL = dangerJs.DSL
 
 type T struct {
 	results Results

--- a/cmd/danger-go/runner/runner.go
+++ b/cmd/danger-go/runner/runner.go
@@ -105,7 +105,7 @@ func buildPlugin(dangerFilePath string) (string, func() error, error) {
 	return outputFile, clearTempDir, nil
 }
 
-type MainFunc = func(d *danger.T, pr dangerJs.DSL)
+type MainFunc = func(d *danger.T, pr danger.DSL)
 
 func loadPlugin(libPath string) (MainFunc, error) {
 	fmt.Println("Loading dangerfile plugin:", libPath)


### PR DESCRIPTION
This change will allow the dangerfiles to only need to import the root danger-go package.